### PR TITLE
.github: add native tests

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -1,0 +1,23 @@
+name: cross
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ['1.14', '1.19']
+        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go-version }}
+    - run: go vet ./...
+    - run: go test -vet=off -v ./...


### PR DESCRIPTION
Currently Earthly was only testing inside a container, but not the whether things work natively. Similarly, it only tested 1.18, but we also need to support go1.14.